### PR TITLE
vllm-tool-calling: add vllm with tool calling for HPU (Intel Gaudi)

### DIFF
--- a/vllm-tool-calling/hpu-granite3.2-8b/inferenceservice.yaml
+++ b/vllm-tool-calling/hpu-granite3.2-8b/inferenceservice.yaml
@@ -1,0 +1,41 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: granite3.2-8b
+    serving.knative.openshift.io/enablePassthrough: 'true'
+    sidecar.istio.io/inject: 'true'
+    #security.opendatahub.io/enable-auth: 'false'
+    #sidecar.istio.io/inject: 'false'
+    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+  name: granite32-8b
+  finalizers:
+    - inferenceservice.finalizers
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  predictor:
+    annotations:
+      serving.knative.dev/progress-deadline: 60m  
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      env:
+      - name: VLLM_SKIP_WARMUP
+        value: 'false'
+      - name: VLLM_GRAPH_RESERVED_MEM
+        value: '0.25'
+      modelFormat:
+        name: vLLM
+      name: ''
+      resources:
+        limits:
+          cpu: '6'
+          memory: 16Gi
+          habana.ai/gaudi: '1'
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          habana.ai/gaudi: '1'
+      runtime: granite32-8b
+      storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:granite-3.2-8b-instruct'

--- a/vllm-tool-calling/hpu-granite3.2-8b/kustomization.yaml
+++ b/vllm-tool-calling/hpu-granite3.2-8b/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: vllm-tool-calling-demo
+
+resources:
+  - oci-data-connection.yaml
+  - servingruntime.yaml
+  - inferenceservice.yaml

--- a/vllm-tool-calling/hpu-granite3.2-8b/oci-data-connection.yaml
+++ b/vllm-tool-calling/hpu-granite3.2-8b/oci-data-connection.yaml
@@ -1,0 +1,13 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: granite-32-8b-instruct
+  labels:
+    opendatahub.io/dashboard: 'true'
+  annotations:
+    opendatahub.io/connection-type-ref: uri-v1
+    openshift.io/description: ''
+    openshift.io/display-name: granite-3.2-8b-instruct
+data:
+  URI: b2NpOi8vcXVheS5pby9yZWRoYXQtYWktc2VydmljZXMvbW9kZWxjYXItY2F0YWxvZzpncmFuaXRlLTMuMi04Yi1pbnN0cnVjdA==
+type: Opaque

--- a/vllm-tool-calling/hpu-granite3.2-8b/servingruntime.yaml
+++ b/vllm-tool-calling/hpu-granite3.2-8b/servingruntime.yaml
@@ -1,0 +1,59 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  annotations:
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
+    opendatahub.io/template-display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
+    opendatahub.io/accelerator-name: gaudi-hpu-profile
+    opendatahub.io/template-name: vllm-gaudi-runtime
+    openshift.io/display-name: granite32-8b
+  name: granite32-8b
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: '8080'
+  containers:
+    - args:
+        - '--port=8080'
+        - '--model=/mnt/models'
+        - '--served-model-name={{.Name}}'
+        - '--enable-auto-tool-choice'
+        - '--tool-call-parser'
+        - granite
+        - '--chat-template'
+        - /app/data/template/tool_chat_template_granite.jinja
+        - '--max-model-len'
+        - '128000'
+        - '--gpu-memory-utilization'
+        - '0.85'
+        - '--block-size'
+        - '128'
+        - '--dtype'
+        - 'bfloat16'     
+      command:
+        - python
+        - '-m'
+        - vllm.entrypoints.openai.api_server
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_home
+      image: quay.io/modh/vllm@sha256:af6a071be36d8a99476f145d1589d7ede97d2760b93335b14ca26de7417e438c
+      name: kserve-container
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 2Gi
+      name: shm

--- a/vllm-tool-calling/hpu-llama3.2-3b/inferenceservice.yaml
+++ b/vllm-tool-calling/hpu-llama3.2-3b/inferenceservice.yaml
@@ -1,0 +1,41 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: llama3.2-3b
+    serving.knative.openshift.io/enablePassthrough: 'true'
+    sidecar.istio.io/inject: 'true'
+    #security.opendatahub.io/enable-auth: 'false'
+    #sidecar.istio.io/inject: 'false'
+    sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+  name: llama32-3b
+  finalizers:
+    - inferenceservice.finalizers
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  predictor:
+    annotations:
+      serving.knative.dev/progress-deadline: 60m  
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      env:
+      - name: VLLM_SKIP_WARMUP
+        value: 'false'
+      - name: VLLM_GRAPH_RESERVED_MEM
+        value: '0.25'
+      modelFormat:
+        name: vLLM
+      name: ''
+      resources:
+        limits:
+          cpu: '6'
+          memory: 16Gi
+          habana.ai/gaudi: '1'
+        requests:
+          cpu: '4'
+          memory: 8Gi
+          habana.ai/gaudi: '1'
+      runtime: llama32-3b
+      storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-3b-instruct'

--- a/vllm-tool-calling/hpu-llama3.2-3b/kustomization.yaml
+++ b/vllm-tool-calling/hpu-llama3.2-3b/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: vllm-tool-calling-demo
+
+resources:
+  - oci-data-connection.yaml
+  - servingruntime.yaml
+  - inferenceservice.yaml

--- a/vllm-tool-calling/hpu-llama3.2-3b/oci-data-connection.yaml
+++ b/vllm-tool-calling/hpu-llama3.2-3b/oci-data-connection.yaml
@@ -1,0 +1,13 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: llama-32-3b-instruct
+  labels:
+    opendatahub.io/dashboard: 'true'
+  annotations:
+    opendatahub.io/connection-type-ref: uri-v1
+    openshift.io/description: ''
+    openshift.io/display-name: llama-3.2-3b-instruct
+data:
+  URI: b2NpOi8vcXVheS5pby9yZWRoYXQtYWktc2VydmljZXMvbW9kZWxjYXItY2F0YWxvZzpsbGFtYS0zLjItM2ItaW5zdHJ1Y3Q=
+type: Opaque

--- a/vllm-tool-calling/hpu-llama3.2-3b/servingruntime.yaml
+++ b/vllm-tool-calling/hpu-llama3.2-3b/servingruntime.yaml
@@ -1,0 +1,59 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  annotations:
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
+    opendatahub.io/template-display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
+    opendatahub.io/accelerator-name: gaudi-hpu-profile
+    opendatahub.io/template-name: vllm-gaudi-runtime
+    openshift.io/display-name: llama32-3b
+  name: llama32-3b
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: '8080'
+  containers:
+    - args:
+        - '--port=8080'
+        - '--model=/mnt/models'
+        - '--served-model-name={{.Name}}'
+        - '--enable-auto-tool-choice'
+        - '--tool-call-parser'
+        - llama3_json
+        - '--chat-template'
+        - /app/data/template/tool_chat_template_llama3.2_json.jinja
+        - '--max-model-len'
+        - '128000'
+        - '--gpu-memory-utilization'
+        - '0.85'
+        - '--block-size'
+        - '128'
+        - '--dtype'
+        - 'bfloat16'
+      command:
+        - python
+        - '-m'
+        - vllm.entrypoints.openai.api_server
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_home
+      image: quay.io/modh/vllm@sha256:af6a071be36d8a99476f145d1589d7ede97d2760b93335b14ca26de7417e438c
+      name: kserve-container
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 2Gi
+      name: shm


### PR DESCRIPTION
added k-serve example to deploy vllm for agentic demo using Gaudi HPU device
tested on OpenShift AI

this is identical to https://github.com/rh-aiservices-bu/rh-summit-agentic-demo/pull/1 with modification in namespace for kustomization