### PR TITLE
Add vLLM parameters to optimize inference on HPU and CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ NOTE: To find more patterns and pre-built ModelCar images, take a look at the [R
 
 ### Minimum hardware requirements
 
-- 8+ vCPUs
+- 8+ vCPUs with 4th Gen Intel® Xeon® Scalable processors or newer
 - 24+ GiB RAM
 - Storage: 30Gi minimum in PVC (larger models may require more)
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ git clone https://github.com/rh-ai-quickstart/vllm-tool-calling.git && \
 ```bash
 export PROJECT="vllm-tool-calling-demo"
 
-oc new-project ${PROJECT}
+oc new-project $PROJECT
 ```
 
 Specify your LLM and device:
@@ -111,13 +111,9 @@ export MODEL="granite3.2-8b"
 export DEVICE="gpu"
 ```
 
-Update the following files in the `vllm-tool-calling/${MODEL}/${DEVICE}` folder if `PROJECT` is different from `vllm-tool-calling-demo`. The `namespace` field must match EXACTLY with the value of `PROJECT` set in the previous step to ensure the model is deployed in the proper namespace.
-- `kustomization.yaml`
-- (For running on CPU only) `chat-template-configmap.yaml`
-
 Deploy the LLM on the target hardware:
 ```bash
-oc apply -k vllm-tool-calling/${MODEL}/${DEVICE}
+oc apply -n $PROJECT -k vllm-tool-calling/$MODEL/$DEVICE
 ```
 
 
@@ -132,3 +128,16 @@ oc apply -k vllm-tool-calling/${MODEL}/${DEVICE}
 * Check the models deployed, and wait until you get the green tick in the Status, meaning that the model is deployed successfully:
 
 ![OpenShift AI Projects](assets/images/rhoai-2.png)
+
+
+### Cleanup
+
+To remove all deployed components:
+```bash
+oc delete -n $PROJECT -f vllm-tool-calling/$MODEL/$DEVICE
+```
+
+Delete the project:
+```bash
+oc delete project $PROJECT
+```

--- a/vllm-tool-calling/granite3.2-8b/cpu/chat-template-configmap.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/chat-template-configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chat-template
-  namespace: vllm-tool-calling-demo
 data:
   tool_chat_template_granite.jinja: |
     {%- if tools %}

--- a/vllm-tool-calling/granite3.2-8b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/inferenceservice.yaml
@@ -15,6 +15,21 @@ spec:
       modelFormat:
         name: vLLM
       name: ''
+      env:
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: '40'
+        - name: VLLM_RPC_TIMEOUT
+          value: '100000'
+        - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+          value: '1'
+        - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
+          value: '120'
+        - name: VLLM_CPU_NUM_OF_RESERVED_CPU
+          value: '0'
+        - name: HF_HUB_DISABLE_XET
+          value: '1'
+        - name: VLLM_CPU_SGL_KERNEL
+          value: '1'
       resources:
         limits:
           cpu: '8'

--- a/vllm-tool-calling/granite3.2-8b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/inferenceservice.yaml
@@ -24,16 +24,14 @@ spec:
           value: '1'
         - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
           value: '120'
-        - name: VLLM_CPU_NUM_OF_RESERVED_CPU
-          value: '0'
         - name: HF_HUB_DISABLE_XET
           value: '1'
         - name: VLLM_CPU_SGL_KERNEL
           value: '1'
       resources:
         limits:
-          cpu: '8'
-          memory: 64Gi
+          cpu: '4'
+          memory: 16Gi
         requests:
           cpu: '4'
           memory: 16Gi

--- a/vllm-tool-calling/granite3.2-8b/cpu/kustomization.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - chat-template-configmap.yaml

--- a/vllm-tool-calling/granite3.2-8b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/servingruntime.yaml
@@ -20,22 +20,26 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - granite
-        - '--chat-template'
-        - /app/data/template/tool_chat_template_granite.jinja
-        - '--max-model-len'
-        - '2048'
-        - '--dtype'
-        - 'bfloat16'
+        - '--tool-call-parser=granite'
+        - '--chat-template=/app/data/template/tool_chat_template_granite.jinja'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=8192'
+        - '--distributed-executor-backend=mp'
+        - '--enable-chunked-prefill'
+        - '--enforce-eager'
+        - '--max-num-batched-tokens=2048'
+        - '--max-num-seqs=256'
+        - '--tensor-parallel-size=2'
+        - '--pipeline-parallel-size=1'
       command:
         - python
         - '-m'
         - vllm.entrypoints.openai.api_server
       env:
         - name: HF_HOME
-          value: /tmp/hf_home
-      image: 'quay.io/modh/vllm:vllm-cpu-v2-25-on-push-h8xq2-build-s390x-image'
+          value: "/tmp/hf_home"
+      image: 'opea/vllm-cpu-ubi:v0.12.0-ubi9'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/vllm-tool-calling/granite3.2-8b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/servingruntime.yaml
@@ -30,12 +30,11 @@ spec:
         - '--enforce-eager'
         - '--max-num-batched-tokens=2048'
         - '--max-num-seqs=256'
-        - '--tensor-parallel-size=2'
+        - '--tensor-parallel-size=1'
         - '--pipeline-parallel-size=1'
       command:
-        - python
-        - '-m'
-        - vllm.entrypoints.openai.api_server
+        - vllm
+        - serve
       env:
         - name: HF_HOME
           value: "/tmp/hf_home"

--- a/vllm-tool-calling/granite3.2-8b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/granite3.2-8b/cpu/servingruntime.yaml
@@ -26,8 +26,6 @@ spec:
         - '--dtype=bfloat16'
         - '--max-model-len=8192'
         - '--distributed-executor-backend=mp'
-        - '--enable-chunked-prefill'
-        - '--enforce-eager'
         - '--max-num-batched-tokens=2048'
         - '--max-num-seqs=256'
         - '--tensor-parallel-size=1'

--- a/vllm-tool-calling/granite3.2-8b/gpu/kustomization.yaml
+++ b/vllm-tool-calling/granite3.2-8b/gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/granite3.2-8b/hpu/configmap.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/configmap.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-gaudi-autocalc-script
+data:
+  vllm-gaudi-autocalc.sh: |
+    #!/bin/bash
+
+    set -e
+
+    # Set paths
+    VLLM_GAUDI_PATH="${1:-.}"
+    VLLM_ARGS_OUTPUT="${2:-/config/vllm_autocalc_output.txt}"
+    ENV_VARS_OUTPUT="${3:-/config/env_vars.txt}"
+    
+    # Export for Python subprocess
+    export VLLM_ARGS_OUTPUT
+    export ENV_VARS_OUTPUT
+    
+    echo "Starting vLLM autocalc initialization..."
+    echo "VLLM_GAUDI_PATH: $VLLM_GAUDI_PATH"
+    echo "VLLM_ARGS_OUTPUT: $VLLM_ARGS_OUTPUT"
+    echo "ENV_VARS_OUTPUT: $ENV_VARS_OUTPUT"
+    
+    if [ ! -d "$VLLM_GAUDI_PATH" ]; then
+        echo "ERROR: VLLM_GAUDI_PATH directory not found: $VLLM_GAUDI_PATH"
+        exit 1
+    fi
+    
+    if [ ! -d "$VLLM_GAUDI_PATH/.cd/server" ]; then
+        echo "ERROR: .cd/server directory not found in $VLLM_GAUDI_PATH"
+        exit 1
+    fi
+
+    cd "${VLLM_GAUDI_PATH}/.cd/server"
+
+    python << 'PYTHON_EOF'
+    import sys
+    import os
+    vllm_gaudi_path = os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')
+    sys.path.insert(0, os.path.join(vllm_gaudi_path, '.cd'))
+    
+    from server.vllm_autocalc import VarsGenerator
+
+    # Initialize with absolute file paths
+    vars_gen = VarsGenerator(
+        defaults_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/server_defaults.yaml",
+        varlist_conf_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/server_user.env",
+        model_def_settings_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/settings_vllm.csv"
+    )
+
+    # Calculate and get variables
+    context = vars_gen.calculate_variables()
+
+    # Override or set specific values
+    context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
+
+    print("=== ALL GENERATED VARIABLES ===")
+    for key, value in sorted(context.items()):
+        print(f"{key}: {value} (type: {type(value).__name__})")
+    print("================================")
+
+    # vLLM api_server recognized arguments (lowercase with hyphens)
+    vllm_args = {
+        'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
+        'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
+        'tensor-parallel-size', 'max-num-batched-tokens'
+    }
+
+    args_list = []
+    env_vars = {}
+
+    for key, value in context.items():
+        # Convert to lowercase and replace underscores with hyphens
+        arg_key = key.lower().replace('_', '-')
+        
+        # Skip complex types and None values
+        if isinstance(value, (dict, list)) or value is None:
+            continue
+        
+        # Check if it should be a vLLM argument
+        if arg_key in vllm_args:
+            if isinstance(value, bool):
+                if value:
+                    args_list.append(f'--{arg_key}')
+            else:
+                args_list.append(f'--{arg_key}={value}')
+        # Everything else: store as environment variable (uppercase original key)
+        else:
+            if not isinstance(value, (dict, list)):
+                env_vars[key] = str(value)
+
+    # Get output paths from environment variables (set by bash wrapper)
+    vllm_args_output = os.environ.get('VLLM_ARGS_OUTPUT', '/config/vllm_autocalc_output.txt')
+    env_vars_output = os.environ.get('ENV_VARS_OUTPUT', '/config/env_vars.txt')
+
+    with open(vllm_args_output, 'w') as f:
+        f.write(' '.join(args_list))
+
+    with open(env_vars_output, 'w') as f:
+        for k, v in env_vars.items():
+            f.write(f"export {k}={v}\n")
+
+    print(f"\n=== vLLM ARGS ===")
+    print(f"Generated vLLM args: {' '.join(args_list)}")
+    print(f"\n=== ENV VARS ===")
+    for k, v in env_vars.items():
+        print(f"{k}={v}")
+    PYTHON_EOF
+
+    echo "vLLM autocalc initialization completed successfully"

--- a/vllm-tool-calling/granite3.2-8b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/inferenceservice.yaml
@@ -19,10 +19,38 @@ spec:
     minReplicas: 1
     model:
       env:
-      - name: VLLM_SKIP_WARMUP
-        value: 'false'
-      - name: VLLM_GRAPH_RESERVED_MEM
-        value: '0.25'
+        - name: EXPERIMENTAL_WEIGHT_SHARING
+          value: '0'
+        - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
+          value: 'true'
+        - name: PT_HPU_LAZY_MODE
+          value: '1'
+        - name: VLLM_DECODE_BLOCK_BUCKET_MAX
+          value: '41280'
+        - name: VLLM_DECODE_BLOCK_BUCKET_STEP
+          value: '256'
+        - name: VLLM_DECODE_BS_BUCKET_STEP
+          value: '32'
+        - name: VLLM_DELAYED_SAMPLING
+          value: 'true'
+        - name: VLLM_EXPONENTIAL_BUCKETING
+          value: 'false'
+        - name: VLLM_GRAPH_PROMPT_RATIO
+          value: '0.6'
+        - name: VLLM_GRAPH_RESERVED_MEM
+          value: '0.06'
+        - name: VLLM_PROMPT_BS_BUCKET_STEP
+          value: '32'
+        - name: VLLM_PROMPT_SEQ_BUCKET_MAX
+          value: '33024'
+        - name: VLLM_PROMPT_SEQ_BUCKET_STEP
+          value: '256'
+        - name: VLLM_PROMPT_USE_FUSEDSDPA
+          value: '1'
+        - name: HF_HUB_DISABLE_XET
+          value: '1'
+        - name: VLLM_SKIP_WARMUP
+          value: 'false'
       modelFormat:
         name: vLLM
       name: ''

--- a/vllm-tool-calling/granite3.2-8b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/inferenceservice.yaml
@@ -6,6 +6,10 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: 'true'
     sidecar.istio.io/inject: 'true'
     sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+    proxy.istio.io/config: |
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "false"
+    traffic.sidecar.istio.io/excludeOutboundPorts: "443,80"
   name: granite32-8b-hpu
   finalizers:
     - inferenceservice.finalizers
@@ -14,9 +18,81 @@ metadata:
 spec:
   predictor:
     annotations:
-      serving.knative.dev/progress-deadline: 60m  
+      serving.knative.dev/progress-deadline: 120m  
+      serving.knative.dev/initContainerTimeout: 30m
     maxReplicas: 1
     minReplicas: 1
+    initContainers:
+      - name: vllm-autocalc-init
+        image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+            
+            echo "=== Starting vLLM Gaudi init container ==="
+            cd /tmp
+            
+            # Git clone with timeout
+            echo "Cloning vllm-gaudi repository with 10 minute timeout..."
+            timeout 600 git clone --depth 1 https://github.com/vllm-project/vllm-gaudi.git || {
+              echo "ERROR: Failed to clone repository"
+              exit 1
+            }
+            
+            # Execute the autocalc script from ConfigMap
+            echo "Executing autocalc script..."
+            export VLLM_GAUDI_PATH=/tmp/vllm-gaudi
+
+            if [ ! -f /scripts/vllm-gaudi-autocalc.sh ]; then
+              echo "ERROR: autocalc script not found at /scripts/vllm-gaudi-autocalc.sh"
+              exit 1
+            fi
+            
+            /scripts/vllm-gaudi-autocalc.sh /tmp/vllm-gaudi || {
+              echo "ERROR: autocalc script failed"
+              exit 1
+            }
+            
+            # Verify output files were created
+            if [ ! -f /config/vllm_autocalc_output.txt ]; then
+              echo "ERROR: vllm_autocalc_output.txt was not created"
+              exit 1
+            fi
+            
+            if [ ! -f /config/env_vars.txt ]; then
+              echo "ERROR: env_vars.txt was not created"
+              exit 1
+            fi
+            
+            echo "=== Init container completed successfully ==="
+            echo "Generated vLLM arguments:"
+            cat /config/vllm_autocalc_output.txt
+            echo ""
+            echo "Generated environment variables:"
+            cat /config/env_vars.txt
+        env:
+          - name: HF_HOME
+            value: "/tmp/hf_home"
+          - name: MODEL
+            value: "ibm-granite/granite-8b-code-instruct-4k"
+        volumeMounts:
+          - mountPath: /config
+            name: generated-config
+            readOnly: false
+          - mountPath: /scripts
+            name: autocalc-script
+            readOnly: true
+        resources:
+          requests:
+            cpu: '2'
+            memory: 4Gi
+            habana.ai/gaudi: '1'
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            habana.ai/gaudi: '1'
     model:
       env:
         - name: HF_HOME
@@ -35,3 +111,23 @@ spec:
           habana.ai/gaudi: '1'
       runtime: granite32-8b-hpu
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:granite-3.2-8b-instruct'
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+        - mountPath: /scripts
+          name: autocalc-script
+          readOnly: true
+        - mountPath: /config
+          name: generated-config
+          readOnly: true
+    volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
+        name: shm
+      - emptyDir: {}
+        name: generated-config
+      - configMap:
+          name: vllm-gaudi-autocalc-script
+          defaultMode: 0755
+        name: autocalc-script

--- a/vllm-tool-calling/granite3.2-8b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/inferenceservice.yaml
@@ -19,38 +19,8 @@ spec:
     minReplicas: 1
     model:
       env:
-        - name: EXPERIMENTAL_WEIGHT_SHARING
-          value: '0'
-        - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
-          value: 'true'
-        - name: PT_HPU_LAZY_MODE
-          value: '1'
-        - name: VLLM_DECODE_BLOCK_BUCKET_MAX
-          value: '41280'
-        - name: VLLM_DECODE_BLOCK_BUCKET_STEP
-          value: '256'
-        - name: VLLM_DECODE_BS_BUCKET_STEP
-          value: '32'
-        - name: VLLM_DELAYED_SAMPLING
-          value: 'true'
-        - name: VLLM_EXPONENTIAL_BUCKETING
-          value: 'false'
-        - name: VLLM_GRAPH_PROMPT_RATIO
-          value: '0.6'
-        - name: VLLM_GRAPH_RESERVED_MEM
-          value: '0.06'
-        - name: VLLM_PROMPT_BS_BUCKET_STEP
-          value: '32'
-        - name: VLLM_PROMPT_SEQ_BUCKET_MAX
-          value: '33024'
-        - name: VLLM_PROMPT_SEQ_BUCKET_STEP
-          value: '256'
-        - name: VLLM_PROMPT_USE_FUSEDSDPA
-          value: '1'
-        - name: HF_HUB_DISABLE_XET
-          value: '1'
-        - name: VLLM_SKIP_WARMUP
-          value: 'false'
+        - name: HF_HOME
+          value: /tmp/hf_home
       modelFormat:
         name: vLLM
       name: ''

--- a/vllm-tool-calling/granite3.2-8b/hpu/kustomization.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/granite3.2-8b/hpu/kustomization.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - configmap.yaml
   - oci-data-connection.yaml
   - servingruntime.yaml
   - inferenceservice.yaml

--- a/vllm-tool-calling/granite3.2-8b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/servingruntime.yaml
@@ -21,26 +21,25 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - granite
-        - '--chat-template'
-        - /app/data/template/tool_chat_template_granite.jinja
-        - '--max-model-len'
-        - '128000'
-        - '--gpu-memory-utilization'
-        - '0.85'
-        - '--block-size'
-        - '128'
-        - '--dtype'
-        - 'bfloat16'     
+        - '--tool-call-parser=granite'
+        - '--chat-template=/app/data/template/tool_chat_template_granite.jinja'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=33024'
+        - '--gpu-memory-util=0.99'
+        - '--max-num-seqs=160'
+        - '--max-num-prefill-seqs=16'
+        - '--num-scheduler-steps=1'
+        - '--use-padding-aware-scheduling'
+        - '--tensor-parallel-size=1'
       command:
         - python
         - '-m'
         - vllm.entrypoints.openai.api_server
       env:
         - name: HF_HOME
-          value: /tmp/hf_home
-      image: 'quay.io/modh/vllm@sha256:af6a071be36d8a99476f145d1589d7ede97d2760b93335b14ca26de7417e438c'
+          value: "/tmp/hf_home"
+      image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/vllm-tool-calling/granite3.2-8b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/servingruntime.yaml
@@ -22,79 +22,28 @@ spec:
         - -c
         - |
           set -e
-          cd /tmp
-          git clone https://github.com/vllm-project/vllm-gaudi.git
-          cd /tmp/vllm-gaudi/.cd/server
           
-          python << 'PYTHON_EOF'
-          import sys
-          sys.path.insert(0, '/tmp/vllm-gaudi/.cd/')
+          echo "=== Starting vLLM API Server ==="
           
-          from server.vllm_autocalc import VarsGenerator
+          # Check if generated config files exist
+          if [ ! -f /config/vllm_autocalc_output.txt ]; then
+            echo "ERROR: vllm_autocalc_output.txt not found in /config"
+            exit 1
+          fi
           
-          # Initialize with absolute file paths
-          vars_gen = VarsGenerator(
-              defaults_path="/tmp/vllm-gaudi/.cd/server/server_defaults.yaml",
-              varlist_conf_path="/tmp/vllm-gaudi/.cd/server/server_user.env",
-              model_def_settings_path="/tmp/vllm-gaudi/.cd/server/settings_vllm.csv"
-          )
+          if [ ! -f /config/env_vars.txt ]; then
+            echo "ERROR: env_vars.txt not found in /config"
+            exit 1
+          fi
           
-          # Calculate and get variables
-          context = vars_gen.calculate_variables()
-
-          # Override or set specific values
-          context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
-          
-          print("=== ALL GENERATED VARIABLES ===")
-          for key, value in sorted(context.items()):
-              print(f"{key}: {value} (type: {type(value).__name__})")
-          print("================================")
-          
-          # vLLM api_server recognized arguments (lowercase with hyphens)
-          vllm_args = {
-              'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
-              'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
-              'tensor-parallel-size', 'max-num-batched-tokens'
-          }
-
-          args_list = []
-          env_vars = {}
-          
-          for key, value in context.items():
-              # Convert to lowercase and replace underscores with hyphens
-              arg_key = key.lower().replace('_', '-')
-              
-              # Skip complex types and None values
-              if isinstance(value, (dict, list)) or value is None:
-                  continue
-              
-              # Check if it should be a vLLM argument
-              if arg_key in vllm_args:
-                  if isinstance(value, bool):
-                      if value:
-                          args_list.append(f'--{arg_key}')
-                  else:
-                      args_list.append(f'--{arg_key}={value}')
-              # Everything else: store as environment variable (uppercase original key)
-              else:
-                  if not isinstance(value, (dict, list)):
-                      env_vars[key] = str(value)
-
-          with open('/config/vllm_autocalc_output.txt', 'w') as f:
-              f.write(' '.join(args_list))
-          
-          with open('/config/env_vars.txt', 'w') as f:
-              for k, v in env_vars.items():
-                  f.write(f"export {k}={v}\n")
-
-          print(f"\n=== vLLM ARGS ===")
-          print(f"Generated vLLM args: {' '.join(args_list)}")
-          print(f"\n=== ENV VARS ===")
-          for k, v in env_vars.items():
-              print(f"{k}={v}")
-          PYTHON_EOF
-          
+          # Source generated environment variables
           source /config/env_vars.txt
+          
+          echo "Generated vLLM arguments:"
+          cat /config/vllm_autocalc_output.txt
+          echo ""
+          
+          # Start vLLM API server with generated and hardcoded arguments
           exec python -m vllm.entrypoints.openai.api_server \
             --port=8080 \
             --model=/mnt/models \
@@ -118,6 +67,10 @@ spec:
           name: shm
         - mountPath: /config
           name: generated-config
+          readOnly: true
+        - mountPath: /scripts
+          name: autocalc-script
+          readOnly: true
   multiModel: false
   supportedModelFormats:
     - autoSelect: true
@@ -129,3 +82,7 @@ spec:
       name: shm
     - emptyDir: {}
       name: generated-config
+    - configMap:
+        name: vllm-gaudi-autocalc-script
+        defaultMode: 0755
+      name: autocalc-script

--- a/vllm-tool-calling/granite3.2-8b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/granite3.2-8b/hpu/servingruntime.yaml
@@ -16,29 +16,98 @@ spec:
     prometheus.io/path: /metrics
     prometheus.io/port: '8080'
   containers:
-    - args:
-        - '--port=8080'
-        - '--model=/mnt/models'
-        - '--served-model-name={{.Name}}'
-        - '--enable-auto-tool-choice'
-        - '--tool-call-parser=granite'
-        - '--chat-template=/app/data/template/tool_chat_template_granite.jinja'
-        - '--block-size=128'
-        - '--dtype=bfloat16'
-        - '--max-model-len=33024'
-        - '--gpu-memory-util=0.99'
-        - '--max-num-seqs=160'
-        - '--max-num-prefill-seqs=16'
-        - '--num-scheduler-steps=1'
-        - '--use-padding-aware-scheduling'
-        - '--tensor-parallel-size=1'
+    - args: []
       command:
-        - python
-        - '-m'
-        - vllm.entrypoints.openai.api_server
+        - sh
+        - -c
+        - |
+          set -e
+          cd /tmp
+          git clone https://github.com/vllm-project/vllm-gaudi.git
+          cd /tmp/vllm-gaudi/.cd/server
+          
+          python << 'PYTHON_EOF'
+          import sys
+          sys.path.insert(0, '/tmp/vllm-gaudi/.cd/')
+          
+          from server.vllm_autocalc import VarsGenerator
+          
+          # Initialize with absolute file paths
+          vars_gen = VarsGenerator(
+              defaults_path="/tmp/vllm-gaudi/.cd/server/server_defaults.yaml",
+              varlist_conf_path="/tmp/vllm-gaudi/.cd/server/server_user.env",
+              model_def_settings_path="/tmp/vllm-gaudi/.cd/server/settings_vllm.csv"
+          )
+          
+          # Calculate and get variables
+          context = vars_gen.calculate_variables()
+
+          # Override or set specific values
+          context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
+          
+          print("=== ALL GENERATED VARIABLES ===")
+          for key, value in sorted(context.items()):
+              print(f"{key}: {value} (type: {type(value).__name__})")
+          print("================================")
+          
+          # vLLM api_server recognized arguments (lowercase with hyphens)
+          vllm_args = {
+              'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
+              'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
+              'tensor-parallel-size', 'max-num-batched-tokens'
+          }
+
+          args_list = []
+          env_vars = {}
+          
+          for key, value in context.items():
+              # Convert to lowercase and replace underscores with hyphens
+              arg_key = key.lower().replace('_', '-')
+              
+              # Skip complex types and None values
+              if isinstance(value, (dict, list)) or value is None:
+                  continue
+              
+              # Check if it should be a vLLM argument
+              if arg_key in vllm_args:
+                  if isinstance(value, bool):
+                      if value:
+                          args_list.append(f'--{arg_key}')
+                  else:
+                      args_list.append(f'--{arg_key}={value}')
+              # Everything else: store as environment variable (uppercase original key)
+              else:
+                  if not isinstance(value, (dict, list)):
+                      env_vars[key] = str(value)
+
+          with open('/config/vllm_autocalc_output.txt', 'w') as f:
+              f.write(' '.join(args_list))
+          
+          with open('/config/env_vars.txt', 'w') as f:
+              for k, v in env_vars.items():
+                  f.write(f"export {k}={v}\n")
+
+          print(f"\n=== vLLM ARGS ===")
+          print(f"Generated vLLM args: {' '.join(args_list)}")
+          print(f"\n=== ENV VARS ===")
+          for k, v in env_vars.items():
+              print(f"{k}={v}")
+          PYTHON_EOF
+          
+          source /config/env_vars.txt
+          exec python -m vllm.entrypoints.openai.api_server \
+            --port=8080 \
+            --model=/mnt/models \
+            --served-model-name={{.Name}} \
+            --enable-auto-tool-choice \
+            --tool-call-parser=granite \
+            --chat-template=/app/data/template/tool_chat_template_granite.jinja \
+            $(cat /config/vllm_autocalc_output.txt)
       env:
         - name: HF_HOME
           value: "/tmp/hf_home"
+        - name: MODEL
+          value: "ibm-granite/granite-8b-code-instruct-4k"
       image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
       name: kserve-container
       ports:
@@ -47,6 +116,8 @@ spec:
       volumeMounts:
         - mountPath: /dev/shm
           name: shm
+        - mountPath: /config
+          name: generated-config
   multiModel: false
   supportedModelFormats:
     - autoSelect: true
@@ -56,3 +127,5 @@ spec:
         medium: Memory
         sizeLimit: 2Gi
       name: shm
+    - emptyDir: {}
+      name: generated-config

--- a/vllm-tool-calling/llama3.2-1b/cpu/chat-template-configmap.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/chat-template-configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chat-template
-  namespace: vllm-tool-calling-demo
 data:
   tool_chat_template_llama3.2_json.jinja: |
     {{- bos_token }}

--- a/vllm-tool-calling/llama3.2-1b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/inferenceservice.yaml
@@ -15,6 +15,25 @@ spec:
       modelFormat:
         name: vLLM
       name: ''
+      env:
+        - name: VLLM_CACHE_DIR
+          value: "/tmp/vllm_cache"
+        - name: XDG_CACHE_HOME
+          value: "/tmp/.cache"
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: "40"
+        - name: VLLM_RPC_TIMEOUT
+          value: "100000"
+        - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+          value: "1"
+        - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
+          value: "120"
+        - name: VLLM_CPU_NUM_OF_RESERVED_CPU
+          value: "0"
+        - name: VLLM_CPU_SGL_KERNEL
+          value: "1"
+        - name: HF_HUB_DISABLE_XET
+          value: "1"
       resources:
         limits:
           cpu: '8'

--- a/vllm-tool-calling/llama3.2-1b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/inferenceservice.yaml
@@ -28,16 +28,14 @@ spec:
           value: "1"
         - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
           value: "120"
-        - name: VLLM_CPU_NUM_OF_RESERVED_CPU
-          value: "0"
         - name: VLLM_CPU_SGL_KERNEL
           value: "1"
         - name: HF_HUB_DISABLE_XET
           value: "1"
       resources:
         limits:
-          cpu: '16'
-          memory: 64Gi
+          cpu: '8'
+          memory: 16Gi
         requests:
           cpu: '8'
           memory: 16Gi

--- a/vllm-tool-calling/llama3.2-1b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/inferenceservice.yaml
@@ -36,10 +36,10 @@ spec:
           value: "1"
       resources:
         limits:
-          cpu: '8'
-          memory: 8Gi
+          cpu: '16'
+          memory: 64Gi
         requests:
-          cpu: '4'
-          memory: 4Gi
+          cpu: '8'
+          memory: 16Gi
       runtime: llama32-1b-cpu
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-1b-instruct'

--- a/vllm-tool-calling/llama3.2-1b/cpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/llama3.2-1b/cpu/oci-data-connection.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/oci-data-connection.yaml
@@ -2,7 +2,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: llama-32-1b-instruct
-  namespace: rcarrata-oci
   labels:
     opendatahub.io/dashboard: 'true'
   annotations:

--- a/vllm-tool-calling/llama3.2-1b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/servingruntime.yaml
@@ -20,22 +20,26 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - llama3_json
-        - '--chat-template'
-        - /app/data/template/tool_chat_template_llama3.2_json.jinja
-        - '--max-model-len'
-        - '2048'
-        - '--dtype'
-        - 'bfloat16'
+        - '--tool-call-parser=llama3_json'
+        - '--chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=8192'
+        - '--distributed-executor-backend=mp'
+        - '--enable-chunked-prefill'
+        - '--enforce-eager'
+        - '--max-num-batched-tokens=2048'
+        - '--max-num-seqs=256'
+        - '--tensor-parallel-size=2'
+        - '--pipeline-parallel-size=1'
       command:
         - python
         - '-m'
         - vllm.entrypoints.openai.api_server
       env:
         - name: HF_HOME
-          value: /tmp/hf_home
-      image: 'quay.io/modh/vllm:vllm-cpu-v2-25-on-push-h8xq2-build-s390x-image'
+          value: "/tmp/hf_home"
+      image: 'opea/vllm-cpu-ubi:v0.12.0-ubi9'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/vllm-tool-calling/llama3.2-1b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/servingruntime.yaml
@@ -30,12 +30,11 @@ spec:
         - '--enforce-eager'
         - '--max-num-batched-tokens=2048'
         - '--max-num-seqs=256'
-        - '--tensor-parallel-size=2'
+        - '--tensor-parallel-size=1'
         - '--pipeline-parallel-size=1'
       command:
-        - python
-        - '-m'
-        - vllm.entrypoints.openai.api_server
+        - vllm
+        - serve
       env:
         - name: HF_HOME
           value: "/tmp/hf_home"

--- a/vllm-tool-calling/llama3.2-1b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-1b/cpu/servingruntime.yaml
@@ -26,8 +26,6 @@ spec:
         - '--dtype=bfloat16'
         - '--max-model-len=8192'
         - '--distributed-executor-backend=mp'
-        - '--enable-chunked-prefill'
-        - '--enforce-eager'
         - '--max-num-batched-tokens=2048'
         - '--max-num-seqs=256'
         - '--tensor-parallel-size=1'

--- a/vllm-tool-calling/llama3.2-1b/gpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-1b/gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/llama3.2-1b/gpu/oci-data-connection.yaml
+++ b/vllm-tool-calling/llama3.2-1b/gpu/oci-data-connection.yaml
@@ -2,7 +2,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: llama-32-1b-instruct
-  namespace: rcarrata-oci
   labels:
     opendatahub.io/dashboard: 'true'
   annotations:

--- a/vllm-tool-calling/llama3.2-1b/hpu/configmap.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/configmap.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-gaudi-autocalc-script
+data:
+  vllm-gaudi-autocalc.sh: |
+    #!/bin/bash
+
+    set -e
+
+    # Set paths
+    VLLM_GAUDI_PATH="${1:-.}"
+    VLLM_ARGS_OUTPUT="${2:-/config/vllm_autocalc_output.txt}"
+    ENV_VARS_OUTPUT="${3:-/config/env_vars.txt}"
+    
+    # Export for Python subprocess
+    export VLLM_ARGS_OUTPUT
+    export ENV_VARS_OUTPUT
+    
+    echo "Starting vLLM autocalc initialization..."
+    echo "VLLM_GAUDI_PATH: $VLLM_GAUDI_PATH"
+    echo "VLLM_ARGS_OUTPUT: $VLLM_ARGS_OUTPUT"
+    echo "ENV_VARS_OUTPUT: $ENV_VARS_OUTPUT"
+    
+    if [ ! -d "$VLLM_GAUDI_PATH" ]; then
+        echo "ERROR: VLLM_GAUDI_PATH directory not found: $VLLM_GAUDI_PATH"
+        exit 1
+    fi
+    
+    if [ ! -d "$VLLM_GAUDI_PATH/.cd/server" ]; then
+        echo "ERROR: .cd/server directory not found in $VLLM_GAUDI_PATH"
+        exit 1
+    fi
+
+    cd "${VLLM_GAUDI_PATH}/.cd/server"
+
+    python << 'PYTHON_EOF'
+    import sys
+    import os
+    vllm_gaudi_path = os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')
+    sys.path.insert(0, os.path.join(vllm_gaudi_path, '.cd'))
+    
+    from server.vllm_autocalc import VarsGenerator
+
+    # Initialize with absolute file paths
+    vars_gen = VarsGenerator(
+        defaults_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/server_defaults.yaml",
+        varlist_conf_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/server_user.env",
+        model_def_settings_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/settings_vllm.csv"
+    )
+
+    # Calculate and get variables
+    context = vars_gen.calculate_variables()
+
+    # Override or set specific values
+    context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
+
+    print("=== ALL GENERATED VARIABLES ===")
+    for key, value in sorted(context.items()):
+        print(f"{key}: {value} (type: {type(value).__name__})")
+    print("================================")
+
+    # vLLM api_server recognized arguments (lowercase with hyphens)
+    vllm_args = {
+        'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
+        'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
+        'tensor-parallel-size', 'max-num-batched-tokens'
+    }
+
+    args_list = []
+    env_vars = {}
+
+    for key, value in context.items():
+        # Convert to lowercase and replace underscores with hyphens
+        arg_key = key.lower().replace('_', '-')
+        
+        # Skip complex types and None values
+        if isinstance(value, (dict, list)) or value is None:
+            continue
+        
+        # Check if it should be a vLLM argument
+        if arg_key in vllm_args:
+            if isinstance(value, bool):
+                if value:
+                    args_list.append(f'--{arg_key}')
+            else:
+                args_list.append(f'--{arg_key}={value}')
+        # Everything else: store as environment variable (uppercase original key)
+        else:
+            if not isinstance(value, (dict, list)):
+                env_vars[key] = str(value)
+
+    # Get output paths from environment variables (set by bash wrapper)
+    vllm_args_output = os.environ.get('VLLM_ARGS_OUTPUT', '/config/vllm_autocalc_output.txt')
+    env_vars_output = os.environ.get('ENV_VARS_OUTPUT', '/config/env_vars.txt')
+
+    with open(vllm_args_output, 'w') as f:
+        f.write(' '.join(args_list))
+
+    with open(env_vars_output, 'w') as f:
+        for k, v in env_vars.items():
+            f.write(f"export {k}={v}\n")
+
+    print(f"\n=== vLLM ARGS ===")
+    print(f"Generated vLLM args: {' '.join(args_list)}")
+    print(f"\n=== ENV VARS ===")
+    for k, v in env_vars.items():
+        print(f"{k}={v}")
+    PYTHON_EOF
+
+    echo "vLLM autocalc initialization completed successfully"

--- a/vllm-tool-calling/llama3.2-1b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/inferenceservice.yaml
@@ -19,10 +19,42 @@ spec:
     minReplicas: 1
     model:
       env:
-      - name: VLLM_SKIP_WARMUP
-        value: 'false'
-      - name: VLLM_GRAPH_RESERVED_MEM
-        value: '0.25'
+        - name: runtime
+          value: 'habana'
+        - name: HABANA_VISIBLE_DEVICES
+          value: 'all'
+        - name: EXPERIMENTAL_WEIGHT_SHARING
+          value: '0'
+        - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
+          value: 'true'
+        - name: PT_HPU_LAZY_MODE
+          value: '1'
+        - name: VLLM_DECODE_BLOCK_BUCKET_MAX
+          value: '66048'
+        - name: VLLM_DECODE_BLOCK_BUCKET_STEP
+          value: '256'
+        - name: VLLM_DECODE_BS_BUCKET_STEP
+          value: '32'
+        - name: VLLM_DELAYED_SAMPLING
+          value: 'true'
+        - name: VLLM_EXPONENTIAL_BUCKETING
+          value: 'false'
+        - name: VLLM_GRAPH_PROMPT_RATIO
+          value: '0.5'
+        - name: VLLM_GRAPH_RESERVED_MEM
+          value: '0.09'
+        - name: VLLM_PROMPT_BS_BUCKET_STEP
+          value: '32'
+        - name: VLLM_PROMPT_SEQ_BUCKET_MAX
+          value: '33024'
+        - name: VLLM_PROMPT_SEQ_BUCKET_STEP
+          value: '256'
+        - name: VLLM_PROMPT_USE_FUSEDSDPA
+          value: '1'
+        - name: HF_HUB_DISABLE_XET
+          value: '1'
+        - name: VLLM_SKIP_WARMUP
+          value: 'false'
       modelFormat:
         name: vLLM
       name: ''

--- a/vllm-tool-calling/llama3.2-1b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/inferenceservice.yaml
@@ -19,42 +19,8 @@ spec:
     minReplicas: 1
     model:
       env:
-        - name: runtime
-          value: 'habana'
-        - name: HABANA_VISIBLE_DEVICES
-          value: 'all'
-        - name: EXPERIMENTAL_WEIGHT_SHARING
-          value: '0'
-        - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
-          value: 'true'
-        - name: PT_HPU_LAZY_MODE
-          value: '1'
-        - name: VLLM_DECODE_BLOCK_BUCKET_MAX
-          value: '66048'
-        - name: VLLM_DECODE_BLOCK_BUCKET_STEP
-          value: '256'
-        - name: VLLM_DECODE_BS_BUCKET_STEP
-          value: '32'
-        - name: VLLM_DELAYED_SAMPLING
-          value: 'true'
-        - name: VLLM_EXPONENTIAL_BUCKETING
-          value: 'false'
-        - name: VLLM_GRAPH_PROMPT_RATIO
-          value: '0.5'
-        - name: VLLM_GRAPH_RESERVED_MEM
-          value: '0.09'
-        - name: VLLM_PROMPT_BS_BUCKET_STEP
-          value: '32'
-        - name: VLLM_PROMPT_SEQ_BUCKET_MAX
-          value: '33024'
-        - name: VLLM_PROMPT_SEQ_BUCKET_STEP
-          value: '256'
-        - name: VLLM_PROMPT_USE_FUSEDSDPA
-          value: '1'
-        - name: HF_HUB_DISABLE_XET
-          value: '1'
-        - name: VLLM_SKIP_WARMUP
-          value: 'false'
+        - name: HF_HOME
+          value: /tmp/hf_home
       modelFormat:
         name: vLLM
       name: ''

--- a/vllm-tool-calling/llama3.2-1b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/inferenceservice.yaml
@@ -6,6 +6,10 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: 'true'
     sidecar.istio.io/inject: 'true'
     sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+    proxy.istio.io/config: |
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "false"
+    traffic.sidecar.istio.io/excludeOutboundPorts: "443,80"
   name: llama32-1b-hpu
   finalizers:
     - inferenceservice.finalizers
@@ -14,9 +18,81 @@ metadata:
 spec:
   predictor:
     annotations:
-      serving.knative.dev/progress-deadline: 60m 
+      serving.knative.dev/progress-deadline: 60m
+      serving.knative.dev/initContainerTimeout: 30m
     maxReplicas: 1
     minReplicas: 1
+    initContainers:
+      - name: vllm-autocalc-init
+        image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+            
+            echo "=== Starting vLLM Gaudi init container ==="
+            cd /tmp
+            
+            # Git clone with timeout
+            echo "Cloning vllm-gaudi repository with 10 minute timeout..."
+            timeout 600 git clone --depth 1 https://github.com/vllm-project/vllm-gaudi.git || {
+              echo "ERROR: Failed to clone repository"
+              exit 1
+            }
+            
+            # Execute the autocalc script from ConfigMap
+            echo "Executing autocalc script..."
+            export VLLM_GAUDI_PATH=/tmp/vllm-gaudi
+
+            if [ ! -f /scripts/vllm-gaudi-autocalc.sh ]; then
+              echo "ERROR: autocalc script not found at /scripts/vllm-gaudi-autocalc.sh"
+              exit 1
+            fi
+            
+            /scripts/vllm-gaudi-autocalc.sh /tmp/vllm-gaudi || {
+              echo "ERROR: autocalc script failed"
+              exit 1
+            }
+            
+            # Verify output files were created
+            if [ ! -f /config/vllm_autocalc_output.txt ]; then
+              echo "ERROR: vllm_autocalc_output.txt was not created"
+              exit 1
+            fi
+            
+            if [ ! -f /config/env_vars.txt ]; then
+              echo "ERROR: env_vars.txt was not created"
+              exit 1
+            fi
+            
+            echo "=== Init container completed successfully ==="
+            echo "Generated vLLM arguments:"
+            cat /config/vllm_autocalc_output.txt
+            echo ""
+            echo "Generated environment variables:"
+            cat /config/env_vars.txt
+        env:
+          - name: HF_HOME
+            value: "/tmp/hf_home"
+          - name: MODEL
+            value: "meta-llama/Llama-3.2-1B-Instruct"
+        volumeMounts:
+          - mountPath: /config
+            name: generated-config
+            readOnly: false
+          - mountPath: /scripts
+            name: autocalc-script
+            readOnly: true
+        resources:
+          requests:
+            cpu: '2'
+            memory: 4Gi
+            habana.ai/gaudi: '1'
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            habana.ai/gaudi: '1'
     model:
       env:
         - name: HF_HOME
@@ -35,3 +111,23 @@ spec:
           habana.ai/gaudi: '1'
       runtime: llama32-1b-hpu
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-1b-instruct'
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+        - mountPath: /scripts
+          name: autocalc-script
+          readOnly: true
+        - mountPath: /config
+          name: generated-config
+          readOnly: true
+    volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
+        name: shm
+      - emptyDir: {}
+        name: generated-config
+      - configMap:
+          name: vllm-gaudi-autocalc-script
+          defaultMode: 0755
+        name: autocalc-script

--- a/vllm-tool-calling/llama3.2-1b/hpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/llama3.2-1b/hpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - configmap.yaml
   - oci-data-connection.yaml
   - servingruntime.yaml
   - inferenceservice.yaml

--- a/vllm-tool-calling/llama3.2-1b/hpu/oci-data-connection.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/oci-data-connection.yaml
@@ -2,7 +2,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: llama-32-1b-instruct
-  namespace: rcarrata-oci
   labels:
     opendatahub.io/dashboard: 'true'
   annotations:

--- a/vllm-tool-calling/llama3.2-1b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/servingruntime.yaml
@@ -21,26 +21,25 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - llama3_json
-        - '--chat-template'
-        - /app/data/template/tool_chat_template_llama3.2_json.jinja
-        - '--max-model-len'
-        - '128000'
-        - '--gpu-memory-utilization'
-        - '0.85'
-        - '--block-size'
-        - '128'
-        - '--dtype'
-        - 'bfloat16'
+        - '--tool-call-parser=llama3_json'
+        - '--chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=33024'
+        - '--gpu-memory-util=0.99'
+        - '--max-num-seqs=256'
+        - '--max-num-prefill-seqs=16'
+        - '--num-scheduler-steps=1'
+        - '--use-padding-aware-scheduling'
+        - '--tensor-parallel-size=1'
       command:
         - python
         - '-m'
         - vllm.entrypoints.openai.api_server
       env:
         - name: HF_HOME
-          value: /tmp/hf_home
-      image: 'quay.io/modh/vllm@sha256:af6a071be36d8a99476f145d1589d7ede97d2760b93335b14ca26de7417e438c'
+          value: "/tmp/hf_home"
+      image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/vllm-tool-calling/llama3.2-1b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/servingruntime.yaml
@@ -22,79 +22,28 @@ spec:
         - -c
         - |
           set -e
-          cd /tmp
-          git clone https://github.com/vllm-project/vllm-gaudi.git
-          cd /tmp/vllm-gaudi/.cd/server
           
-          python << 'PYTHON_EOF'
-          import sys
-          sys.path.insert(0, '/tmp/vllm-gaudi/.cd/')
+          echo "=== Starting vLLM API Server ==="
           
-          from server.vllm_autocalc import VarsGenerator
+          # Check if generated config files exist
+          if [ ! -f /config/vllm_autocalc_output.txt ]; then
+            echo "ERROR: vllm_autocalc_output.txt not found in /config"
+            exit 1
+          fi
           
-          # Initialize with absolute file paths
-          vars_gen = VarsGenerator(
-              defaults_path="/tmp/vllm-gaudi/.cd/server/server_defaults.yaml",
-              varlist_conf_path="/tmp/vllm-gaudi/.cd/server/server_user.env",
-              model_def_settings_path="/tmp/vllm-gaudi/.cd/server/settings_vllm.csv"
-          )
+          if [ ! -f /config/env_vars.txt ]; then
+            echo "ERROR: env_vars.txt not found in /config"
+            exit 1
+          fi
           
-          # Calculate and get variables
-          context = vars_gen.calculate_variables()
-
-          # Override or set specific values
-          context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
-          
-          print("=== ALL GENERATED VARIABLES ===")
-          for key, value in sorted(context.items()):
-              print(f"{key}: {value} (type: {type(value).__name__})")
-          print("================================")
-          
-          # vLLM api_server recognized arguments (lowercase with hyphens)
-          vllm_args = {
-              'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
-              'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
-              'tensor-parallel-size', 'max-num-batched-tokens'
-          }
-
-          args_list = []
-          env_vars = {}
-          
-          for key, value in context.items():
-              # Convert to lowercase and replace underscores with hyphens
-              arg_key = key.lower().replace('_', '-')
-              
-              # Skip complex types and None values
-              if isinstance(value, (dict, list)) or value is None:
-                  continue
-              
-              # Check if it should be a vLLM argument
-              if arg_key in vllm_args:
-                  if isinstance(value, bool):
-                      if value:
-                          args_list.append(f'--{arg_key}')
-                  else:
-                      args_list.append(f'--{arg_key}={value}')
-              # Everything else: store as environment variable (uppercase original key)
-              else:
-                  if not isinstance(value, (dict, list)):
-                      env_vars[key] = str(value)
-
-          with open('/config/vllm_autocalc_output.txt', 'w') as f:
-              f.write(' '.join(args_list))
-          
-          with open('/config/env_vars.txt', 'w') as f:
-              for k, v in env_vars.items():
-                  f.write(f"export {k}={v}\n")
-
-          print(f"\n=== vLLM ARGS ===")
-          print(f"Generated vLLM args: {' '.join(args_list)}")
-          print(f"\n=== ENV VARS ===")
-          for k, v in env_vars.items():
-              print(f"{k}={v}")
-          PYTHON_EOF
-          
+          # Source generated environment variables
           source /config/env_vars.txt
+          
+          echo "Generated vLLM arguments:"
+          cat /config/vllm_autocalc_output.txt
+          echo ""
+          
+          # Start vLLM API server with generated and hardcoded arguments
           exec python -m vllm.entrypoints.openai.api_server \
             --port=8080 \
             --model=/mnt/models \
@@ -118,6 +67,10 @@ spec:
           name: shm
         - mountPath: /config
           name: generated-config
+          readOnly: true
+        - mountPath: /scripts
+          name: autocalc-script
+          readOnly: true
   multiModel: false
   supportedModelFormats:
     - autoSelect: true
@@ -129,3 +82,7 @@ spec:
       name: shm
     - emptyDir: {}
       name: generated-config
+    - configMap:
+        name: vllm-gaudi-autocalc-script
+        defaultMode: 0755
+      name: autocalc-script

--- a/vllm-tool-calling/llama3.2-1b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-1b/hpu/servingruntime.yaml
@@ -16,29 +16,98 @@ spec:
     prometheus.io/path: /metrics
     prometheus.io/port: '8080'
   containers:
-    - args:
-        - '--port=8080'
-        - '--model=/mnt/models'
-        - '--served-model-name={{.Name}}'
-        - '--enable-auto-tool-choice'
-        - '--tool-call-parser=llama3_json'
-        - '--chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja'
-        - '--block-size=128'
-        - '--dtype=bfloat16'
-        - '--max-model-len=33024'
-        - '--gpu-memory-util=0.99'
-        - '--max-num-seqs=256'
-        - '--max-num-prefill-seqs=16'
-        - '--num-scheduler-steps=1'
-        - '--use-padding-aware-scheduling'
-        - '--tensor-parallel-size=1'
+    - args: []
       command:
-        - python
-        - '-m'
-        - vllm.entrypoints.openai.api_server
+        - sh
+        - -c
+        - |
+          set -e
+          cd /tmp
+          git clone https://github.com/vllm-project/vllm-gaudi.git
+          cd /tmp/vllm-gaudi/.cd/server
+          
+          python << 'PYTHON_EOF'
+          import sys
+          sys.path.insert(0, '/tmp/vllm-gaudi/.cd/')
+          
+          from server.vllm_autocalc import VarsGenerator
+          
+          # Initialize with absolute file paths
+          vars_gen = VarsGenerator(
+              defaults_path="/tmp/vllm-gaudi/.cd/server/server_defaults.yaml",
+              varlist_conf_path="/tmp/vllm-gaudi/.cd/server/server_user.env",
+              model_def_settings_path="/tmp/vllm-gaudi/.cd/server/settings_vllm.csv"
+          )
+          
+          # Calculate and get variables
+          context = vars_gen.calculate_variables()
+
+          # Override or set specific values
+          context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
+          
+          print("=== ALL GENERATED VARIABLES ===")
+          for key, value in sorted(context.items()):
+              print(f"{key}: {value} (type: {type(value).__name__})")
+          print("================================")
+          
+          # vLLM api_server recognized arguments (lowercase with hyphens)
+          vllm_args = {
+              'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
+              'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
+              'tensor-parallel-size', 'max-num-batched-tokens'
+          }
+
+          args_list = []
+          env_vars = {}
+          
+          for key, value in context.items():
+              # Convert to lowercase and replace underscores with hyphens
+              arg_key = key.lower().replace('_', '-')
+              
+              # Skip complex types and None values
+              if isinstance(value, (dict, list)) or value is None:
+                  continue
+              
+              # Check if it should be a vLLM argument
+              if arg_key in vllm_args:
+                  if isinstance(value, bool):
+                      if value:
+                          args_list.append(f'--{arg_key}')
+                  else:
+                      args_list.append(f'--{arg_key}={value}')
+              # Everything else: store as environment variable (uppercase original key)
+              else:
+                  if not isinstance(value, (dict, list)):
+                      env_vars[key] = str(value)
+
+          with open('/config/vllm_autocalc_output.txt', 'w') as f:
+              f.write(' '.join(args_list))
+          
+          with open('/config/env_vars.txt', 'w') as f:
+              for k, v in env_vars.items():
+                  f.write(f"export {k}={v}\n")
+
+          print(f"\n=== vLLM ARGS ===")
+          print(f"Generated vLLM args: {' '.join(args_list)}")
+          print(f"\n=== ENV VARS ===")
+          for k, v in env_vars.items():
+              print(f"{k}={v}")
+          PYTHON_EOF
+          
+          source /config/env_vars.txt
+          exec python -m vllm.entrypoints.openai.api_server \
+            --port=8080 \
+            --model=/mnt/models \
+            --served-model-name={{.Name}} \
+            --enable-auto-tool-choice \
+            --tool-call-parser=llama3_json \
+            --chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja \
+            $(cat /config/vllm_autocalc_output.txt)
       env:
         - name: HF_HOME
           value: "/tmp/hf_home"
+        - name: MODEL
+          value: "meta-llama/Llama-3.2-1B-Instruct"
       image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
       name: kserve-container
       ports:
@@ -47,6 +116,8 @@ spec:
       volumeMounts:
         - mountPath: /dev/shm
           name: shm
+        - mountPath: /config
+          name: generated-config
   multiModel: false
   supportedModelFormats:
     - autoSelect: true
@@ -56,3 +127,5 @@ spec:
         medium: Memory
         sizeLimit: 2Gi
       name: shm
+    - emptyDir: {}
+      name: generated-config

--- a/vllm-tool-calling/llama3.2-3b/cpu/chat-template-configmap.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/chat-template-configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: chat-template
-  namespace: vllm-tool-calling-demo
 data:
   tool_chat_template_llama3.2_json.jinja: |
     {{- bos_token }}

--- a/vllm-tool-calling/llama3.2-3b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/inferenceservice.yaml
@@ -15,12 +15,31 @@ spec:
       modelFormat:
         name: vLLM
       name: ''
+      env:
+        - name: VLLM_CACHE_DIR
+          value: "/tmp/vllm_cache"
+        - name: XDG_CACHE_HOME
+          value: "/tmp/.cache"
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: "40"
+        - name: VLLM_RPC_TIMEOUT
+          value: "100000"
+        - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+          value: "1"
+        - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
+          value: "120"
+        - name: VLLM_CPU_NUM_OF_RESERVED_CPU
+          value: "0"
+        - name: VLLM_CPU_SGL_KERNEL
+          value: "1"
+        - name: HF_HUB_DISABLE_XET
+          value: "1"
       resources:
         limits:
-          cpu: '8'
+          cpu: '16'
           memory: 24Gi
         requests:
-          cpu: '4'
+          cpu: '8'
           memory: 12Gi
       runtime: llama32-3b-cpu
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-3b-instruct'

--- a/vllm-tool-calling/llama3.2-3b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/inferenceservice.yaml
@@ -28,16 +28,14 @@ spec:
           value: "1"
         - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
           value: "120"
-        - name: VLLM_CPU_NUM_OF_RESERVED_CPU
-          value: "0"
         - name: VLLM_CPU_SGL_KERNEL
           value: "1"
         - name: HF_HUB_DISABLE_XET
           value: "1"
       resources:
         limits:
-          cpu: '16'
-          memory: 64Gi
+          cpu: '8'
+          memory: 16Gi
         requests:
           cpu: '8'
           memory: 16Gi

--- a/vllm-tool-calling/llama3.2-3b/cpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/inferenceservice.yaml
@@ -37,9 +37,9 @@ spec:
       resources:
         limits:
           cpu: '16'
-          memory: 24Gi
+          memory: 64Gi
         requests:
           cpu: '8'
-          memory: 12Gi
+          memory: 16Gi
       runtime: llama32-3b-cpu
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-3b-instruct'

--- a/vllm-tool-calling/llama3.2-3b/cpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - chat-template-configmap.yaml

--- a/vllm-tool-calling/llama3.2-3b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/servingruntime.yaml
@@ -20,22 +20,26 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - llama3_json
-        - '--chat-template'
-        - /app/data/template/tool_chat_template_llama3.2_json.jinja
-        - '--max-model-len'
-        - '2048'
-        - '--dtype'
-        - 'bfloat16'
+        - '--tool-call-parser=llama3_json'
+        - '--chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=8192'
+        - '--distributed-executor-backend=mp'
+        - '--enable-chunked-prefill'
+        - '--enforce-eager'
+        - '--max-num-batched-tokens=2048'
+        - '--max-num-seqs=256'
+        - '--tensor-parallel-size=2'
+        - '--pipeline-parallel-size=1'
       command:
         - python
         - '-m'
         - vllm.entrypoints.openai.api_server
       env:
         - name: HF_HOME
-          value: /tmp/hf_home
-      image: 'quay.io/modh/vllm:vllm-cpu-v2-25-on-push-h8xq2-build-s390x-image'
+          value: "/tmp/hf_home"
+      image: 'opea/vllm-cpu-ubi:v0.12.0-ubi9'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/vllm-tool-calling/llama3.2-3b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/servingruntime.yaml
@@ -30,12 +30,11 @@ spec:
         - '--enforce-eager'
         - '--max-num-batched-tokens=2048'
         - '--max-num-seqs=256'
-        - '--tensor-parallel-size=2'
+        - '--tensor-parallel-size=1'
         - '--pipeline-parallel-size=1'
       command:
-        - python
-        - '-m'
-        - vllm.entrypoints.openai.api_server
+        - vllm
+        - serve
       env:
         - name: HF_HOME
           value: "/tmp/hf_home"

--- a/vllm-tool-calling/llama3.2-3b/cpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-3b/cpu/servingruntime.yaml
@@ -26,8 +26,6 @@ spec:
         - '--dtype=bfloat16'
         - '--max-model-len=8192'
         - '--distributed-executor-backend=mp'
-        - '--enable-chunked-prefill'
-        - '--enforce-eager'
         - '--max-num-batched-tokens=2048'
         - '--max-num-seqs=256'
         - '--tensor-parallel-size=1'

--- a/vllm-tool-calling/llama3.2-3b/gpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-3b/gpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/llama3.2-3b/hpu/configmap.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/configmap.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vllm-gaudi-autocalc-script
+data:
+  vllm-gaudi-autocalc.sh: |
+    #!/bin/bash
+
+    set -e
+
+    # Set paths
+    VLLM_GAUDI_PATH="${1:-.}"
+    VLLM_ARGS_OUTPUT="${2:-/config/vllm_autocalc_output.txt}"
+    ENV_VARS_OUTPUT="${3:-/config/env_vars.txt}"
+    
+    # Export for Python subprocess
+    export VLLM_ARGS_OUTPUT
+    export ENV_VARS_OUTPUT
+    
+    echo "Starting vLLM autocalc initialization..."
+    echo "VLLM_GAUDI_PATH: $VLLM_GAUDI_PATH"
+    echo "VLLM_ARGS_OUTPUT: $VLLM_ARGS_OUTPUT"
+    echo "ENV_VARS_OUTPUT: $ENV_VARS_OUTPUT"
+    
+    if [ ! -d "$VLLM_GAUDI_PATH" ]; then
+        echo "ERROR: VLLM_GAUDI_PATH directory not found: $VLLM_GAUDI_PATH"
+        exit 1
+    fi
+    
+    if [ ! -d "$VLLM_GAUDI_PATH/.cd/server" ]; then
+        echo "ERROR: .cd/server directory not found in $VLLM_GAUDI_PATH"
+        exit 1
+    fi
+
+    cd "${VLLM_GAUDI_PATH}/.cd/server"
+
+    python << 'PYTHON_EOF'
+    import sys
+    import os
+    vllm_gaudi_path = os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')
+    sys.path.insert(0, os.path.join(vllm_gaudi_path, '.cd'))
+    
+    from server.vllm_autocalc import VarsGenerator
+
+    # Initialize with absolute file paths
+    vars_gen = VarsGenerator(
+        defaults_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/server_defaults.yaml",
+        varlist_conf_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/server_user.env",
+        model_def_settings_path=f"{os.environ.get('VLLM_GAUDI_PATH', '/tmp/vllm-gaudi')}/.cd/server/settings_vllm.csv"
+    )
+
+    # Calculate and get variables
+    context = vars_gen.calculate_variables()
+
+    # Override or set specific values
+    context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
+
+    print("=== ALL GENERATED VARIABLES ===")
+    for key, value in sorted(context.items()):
+        print(f"{key}: {value} (type: {type(value).__name__})")
+    print("================================")
+
+    # vLLM api_server recognized arguments (lowercase with hyphens)
+    vllm_args = {
+        'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
+        'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
+        'tensor-parallel-size', 'max-num-batched-tokens'
+    }
+
+    args_list = []
+    env_vars = {}
+
+    for key, value in context.items():
+        # Convert to lowercase and replace underscores with hyphens
+        arg_key = key.lower().replace('_', '-')
+        
+        # Skip complex types and None values
+        if isinstance(value, (dict, list)) or value is None:
+            continue
+        
+        # Check if it should be a vLLM argument
+        if arg_key in vllm_args:
+            if isinstance(value, bool):
+                if value:
+                    args_list.append(f'--{arg_key}')
+            else:
+                args_list.append(f'--{arg_key}={value}')
+        # Everything else: store as environment variable (uppercase original key)
+        else:
+            if not isinstance(value, (dict, list)):
+                env_vars[key] = str(value)
+
+    # Get output paths from environment variables (set by bash wrapper)
+    vllm_args_output = os.environ.get('VLLM_ARGS_OUTPUT', '/config/vllm_autocalc_output.txt')
+    env_vars_output = os.environ.get('ENV_VARS_OUTPUT', '/config/env_vars.txt')
+
+    with open(vllm_args_output, 'w') as f:
+        f.write(' '.join(args_list))
+
+    with open(env_vars_output, 'w') as f:
+        for k, v in env_vars.items():
+            f.write(f"export {k}={v}\n")
+
+    print(f"\n=== vLLM ARGS ===")
+    print(f"Generated vLLM args: {' '.join(args_list)}")
+    print(f"\n=== ENV VARS ===")
+    for k, v in env_vars.items():
+        print(f"{k}={v}")
+    PYTHON_EOF
+
+    echo "vLLM autocalc initialization completed successfully"

--- a/vllm-tool-calling/llama3.2-3b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/inferenceservice.yaml
@@ -18,14 +18,46 @@ spec:
     maxReplicas: 1
     minReplicas: 1
     model:
-      env:
-      - name: VLLM_SKIP_WARMUP
-        value: 'false'
-      - name: VLLM_GRAPH_RESERVED_MEM
-        value: '0.25'
       modelFormat:
         name: vLLM
       name: ''
+      env:
+        - name: runtime
+          value: 'habana'
+        - name: HABANA_VISIBLE_DEVICES
+          value: 'all'
+        - name: EXPERIMENTAL_WEIGHT_SHARING
+          value: '0'
+        - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
+          value: 'true'
+        - name: PT_HPU_LAZY_MODE
+          value: '1'
+        - name: VLLM_DECODE_BLOCK_BUCKET_MAX
+          value: '66048'
+        - name: VLLM_DECODE_BLOCK_BUCKET_STEP
+          value: '256'
+        - name: VLLM_DECODE_BS_BUCKET_STEP
+          value: '32'
+        - name: VLLM_DELAYED_SAMPLING
+          value: 'true'
+        - name: VLLM_EXPONENTIAL_BUCKETING
+          value: 'false'
+        - name: VLLM_GRAPH_PROMPT_RATIO
+          value: '0.5'
+        - name: VLLM_GRAPH_RESERVED_MEM
+          value: '0.09'
+        - name: VLLM_PROMPT_BS_BUCKET_STEP
+          value: '32'
+        - name: VLLM_PROMPT_SEQ_BUCKET_MAX
+          value: '33024'
+        - name: VLLM_PROMPT_SEQ_BUCKET_STEP
+          value: '256'
+        - name: VLLM_PROMPT_USE_FUSEDSDPA
+          value: '1'
+        - name: HF_HUB_DISABLE_XET
+          value: '1'
+        - name: VLLM_SKIP_WARMUP
+          value: 'false'
       resources:
         limits:
           cpu: '6'

--- a/vllm-tool-calling/llama3.2-3b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/inferenceservice.yaml
@@ -6,6 +6,10 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: 'true'
     sidecar.istio.io/inject: 'true'
     sidecar.istio.io/rewriteAppHTTPProbers: 'true'
+    proxy.istio.io/config: |
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "false"
+    traffic.sidecar.istio.io/excludeOutboundPorts: "443,80"
   name: llama32-3b-hpu
   finalizers:
     - inferenceservice.finalizers
@@ -14,9 +18,81 @@ metadata:
 spec:
   predictor:
     annotations:
-      serving.knative.dev/progress-deadline: 60m  
+      serving.knative.dev/progress-deadline: 60m
+      serving.knative.dev/initContainerTimeout: 30m
     maxReplicas: 1
     minReplicas: 1
+    initContainers:
+      - name: vllm-autocalc-init
+        image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+            
+            echo "=== Starting vLLM Gaudi init container ==="
+            cd /tmp
+            
+            # Git clone with timeout
+            echo "Cloning vllm-gaudi repository with 10 minute timeout..."
+            timeout 600 git clone --depth 1 https://github.com/vllm-project/vllm-gaudi.git || {
+              echo "ERROR: Failed to clone repository"
+              exit 1
+            }
+            
+            # Execute the autocalc script from ConfigMap
+            echo "Executing autocalc script..."
+            export VLLM_GAUDI_PATH=/tmp/vllm-gaudi
+
+            if [ ! -f /scripts/vllm-gaudi-autocalc.sh ]; then
+              echo "ERROR: autocalc script not found at /scripts/vllm-gaudi-autocalc.sh"
+              exit 1
+            fi
+            
+            /scripts/vllm-gaudi-autocalc.sh /tmp/vllm-gaudi || {
+              echo "ERROR: autocalc script failed"
+              exit 1
+            }
+            
+            # Verify output files were created
+            if [ ! -f /config/vllm_autocalc_output.txt ]; then
+              echo "ERROR: vllm_autocalc_output.txt was not created"
+              exit 1
+            fi
+            
+            if [ ! -f /config/env_vars.txt ]; then
+              echo "ERROR: env_vars.txt was not created"
+              exit 1
+            fi
+            
+            echo "=== Init container completed successfully ==="
+            echo "Generated vLLM arguments:"
+            cat /config/vllm_autocalc_output.txt
+            echo ""
+            echo "Generated environment variables:"
+            cat /config/env_vars.txt
+        env:
+          - name: HF_HOME
+            value: "/tmp/hf_home"
+          - name: MODEL
+            value: "meta-llama/Llama-3.2-3B-Instruct"
+        volumeMounts:
+          - mountPath: /config
+            name: generated-config
+            readOnly: false
+          - mountPath: /scripts
+            name: autocalc-script
+            readOnly: true
+        resources:
+          requests:
+            cpu: '2'
+            memory: 4Gi
+            habana.ai/gaudi: '1'
+          limits:
+            cpu: '4'
+            memory: 8Gi
+            habana.ai/gaudi: '1'
     model:
       modelFormat:
         name: vLLM
@@ -35,3 +111,23 @@ spec:
           habana.ai/gaudi: '1'
       runtime: llama32-3b-hpu
       storageUri: 'oci://quay.io/redhat-ai-services/modelcar-catalog:llama-3.2-3b-instruct'
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+        - mountPath: /scripts
+          name: autocalc-script
+          readOnly: true
+        - mountPath: /config
+          name: generated-config
+          readOnly: true
+    volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
+        name: shm
+      - emptyDir: {}
+        name: generated-config
+      - configMap:
+          name: vllm-gaudi-autocalc-script
+          defaultMode: 0755
+        name: autocalc-script

--- a/vllm-tool-calling/llama3.2-3b/hpu/inferenceservice.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/inferenceservice.yaml
@@ -22,42 +22,8 @@ spec:
         name: vLLM
       name: ''
       env:
-        - name: runtime
-          value: 'habana'
-        - name: HABANA_VISIBLE_DEVICES
-          value: 'all'
-        - name: EXPERIMENTAL_WEIGHT_SHARING
-          value: '0'
-        - name: PT_HPU_ENABLE_LAZY_COLLECTIVES
-          value: 'true'
-        - name: PT_HPU_LAZY_MODE
-          value: '1'
-        - name: VLLM_DECODE_BLOCK_BUCKET_MAX
-          value: '66048'
-        - name: VLLM_DECODE_BLOCK_BUCKET_STEP
-          value: '256'
-        - name: VLLM_DECODE_BS_BUCKET_STEP
-          value: '32'
-        - name: VLLM_DELAYED_SAMPLING
-          value: 'true'
-        - name: VLLM_EXPONENTIAL_BUCKETING
-          value: 'false'
-        - name: VLLM_GRAPH_PROMPT_RATIO
-          value: '0.5'
-        - name: VLLM_GRAPH_RESERVED_MEM
-          value: '0.09'
-        - name: VLLM_PROMPT_BS_BUCKET_STEP
-          value: '32'
-        - name: VLLM_PROMPT_SEQ_BUCKET_MAX
-          value: '33024'
-        - name: VLLM_PROMPT_SEQ_BUCKET_STEP
-          value: '256'
-        - name: VLLM_PROMPT_USE_FUSEDSDPA
-          value: '1'
-        - name: HF_HUB_DISABLE_XET
-          value: '1'
-        - name: VLLM_SKIP_WARMUP
-          value: 'false'
+        - name: HF_HOME
+          value: /tmp/hf_home
       resources:
         limits:
           cpu: '6'

--- a/vllm-tool-calling/llama3.2-3b/hpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vllm-tool-calling-demo
-
 resources:
   - oci-data-connection.yaml
   - servingruntime.yaml

--- a/vllm-tool-calling/llama3.2-3b/hpu/kustomization.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - configmap.yaml
   - oci-data-connection.yaml
   - servingruntime.yaml
   - inferenceservice.yaml

--- a/vllm-tool-calling/llama3.2-3b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/servingruntime.yaml
@@ -21,26 +21,25 @@ spec:
         - '--model=/mnt/models'
         - '--served-model-name={{.Name}}'
         - '--enable-auto-tool-choice'
-        - '--tool-call-parser'
-        - llama3_json
-        - '--chat-template'
-        - /app/data/template/tool_chat_template_llama3.2_json.jinja
-        - '--max-model-len'
-        - '128000'
-        - '--gpu-memory-utilization'
-        - '0.85'
-        - '--block-size'
-        - '128'
-        - '--dtype'
-        - 'bfloat16'
+        - '--tool-call-parser=llama3_json'
+        - '--chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=33024'
+        - '--gpu-memory-util=0.99'
+        - '--max-num-seqs=256'
+        - '--max-num-prefill-seqs=16'
+        - '--num-scheduler-steps=1'
+        - '--use-padding-aware-scheduling'
+        - '--tensor-parallel-size=1'
       command:
         - python
         - '-m'
         - vllm.entrypoints.openai.api_server
       env:
         - name: HF_HOME
-          value: /tmp/hf_home
-      image: 'quay.io/modh/vllm@sha256:af6a071be36d8a99476f145d1589d7ede97d2760b93335b14ca26de7417e438c'
+          value: "/tmp/hf_home"
+      image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/vllm-tool-calling/llama3.2-3b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/servingruntime.yaml
@@ -22,79 +22,28 @@ spec:
         - -c
         - |
           set -e
-          cd /tmp
-          git clone https://github.com/vllm-project/vllm-gaudi.git
-          cd /tmp/vllm-gaudi/.cd/server
           
-          python << 'PYTHON_EOF'
-          import sys
-          sys.path.insert(0, '/tmp/vllm-gaudi/.cd/')
+          echo "=== Starting vLLM API Server ==="
           
-          from server.vllm_autocalc import VarsGenerator
+          # Check if generated config files exist
+          if [ ! -f /config/vllm_autocalc_output.txt ]; then
+            echo "ERROR: vllm_autocalc_output.txt not found in /config"
+            exit 1
+          fi
           
-          # Initialize with absolute file paths
-          vars_gen = VarsGenerator(
-              defaults_path="/tmp/vllm-gaudi/.cd/server/server_defaults.yaml",
-              varlist_conf_path="/tmp/vllm-gaudi/.cd/server/server_user.env",
-              model_def_settings_path="/tmp/vllm-gaudi/.cd/server/settings_vllm.csv"
-          )
+          if [ ! -f /config/env_vars.txt ]; then
+            echo "ERROR: env_vars.txt not found in /config"
+            exit 1
+          fi
           
-          # Calculate and get variables
-          context = vars_gen.calculate_variables()
-
-          # Override or set specific values
-          context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
-          
-          print("=== ALL GENERATED VARIABLES ===")
-          for key, value in sorted(context.items()):
-              print(f"{key}: {value} (type: {type(value).__name__})")
-          print("================================")
-          
-          # vLLM api_server recognized arguments (lowercase with hyphens)
-          vllm_args = {
-              'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
-              'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
-              'tensor-parallel-size', 'max-num-batched-tokens'
-          }
-
-          args_list = []
-          env_vars = {}
-          
-          for key, value in context.items():
-              # Convert to lowercase and replace underscores with hyphens
-              arg_key = key.lower().replace('_', '-')
-              
-              # Skip complex types and None values
-              if isinstance(value, (dict, list)) or value is None:
-                  continue
-              
-              # Check if it should be a vLLM argument
-              if arg_key in vllm_args:
-                  if isinstance(value, bool):
-                      if value:
-                          args_list.append(f'--{arg_key}')
-                  else:
-                      args_list.append(f'--{arg_key}={value}')
-              # Everything else: store as environment variable (uppercase original key)
-              else:
-                  if not isinstance(value, (dict, list)):
-                      env_vars[key] = str(value)
-
-          with open('/config/vllm_autocalc_output.txt', 'w') as f:
-              f.write(' '.join(args_list))
-          
-          with open('/config/env_vars.txt', 'w') as f:
-              for k, v in env_vars.items():
-                  f.write(f"export {k}={v}\n")
-
-          print(f"\n=== vLLM ARGS ===")
-          print(f"Generated vLLM args: {' '.join(args_list)}")
-          print(f"\n=== ENV VARS ===")
-          for k, v in env_vars.items():
-              print(f"{k}={v}")
-          PYTHON_EOF
-          
+          # Source generated environment variables
           source /config/env_vars.txt
+          
+          echo "Generated vLLM arguments:"
+          cat /config/vllm_autocalc_output.txt
+          echo ""
+          
+          # Start vLLM API server with generated and hardcoded arguments
           exec python -m vllm.entrypoints.openai.api_server \
             --port=8080 \
             --model=/mnt/models \
@@ -118,6 +67,10 @@ spec:
           name: shm
         - mountPath: /config
           name: generated-config
+          readOnly: true
+        - mountPath: /scripts
+          name: autocalc-script
+          readOnly: true
   multiModel: false
   supportedModelFormats:
     - autoSelect: true
@@ -129,3 +82,7 @@ spec:
       name: shm
     - emptyDir: {}
       name: generated-config
+    - configMap:
+        name: vllm-gaudi-autocalc-script
+        defaultMode: 0755
+      name: autocalc-script

--- a/vllm-tool-calling/llama3.2-3b/hpu/servingruntime.yaml
+++ b/vllm-tool-calling/llama3.2-3b/hpu/servingruntime.yaml
@@ -16,29 +16,98 @@ spec:
     prometheus.io/path: /metrics
     prometheus.io/port: '8080'
   containers:
-    - args:
-        - '--port=8080'
-        - '--model=/mnt/models'
-        - '--served-model-name={{.Name}}'
-        - '--enable-auto-tool-choice'
-        - '--tool-call-parser=llama3_json'
-        - '--chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja'
-        - '--block-size=128'
-        - '--dtype=bfloat16'
-        - '--max-model-len=33024'
-        - '--gpu-memory-util=0.99'
-        - '--max-num-seqs=256'
-        - '--max-num-prefill-seqs=16'
-        - '--num-scheduler-steps=1'
-        - '--use-padding-aware-scheduling'
-        - '--tensor-parallel-size=1'
+    - args: []
       command:
-        - python
-        - '-m'
-        - vllm.entrypoints.openai.api_server
+        - sh
+        - -c
+        - |
+          set -e
+          cd /tmp
+          git clone https://github.com/vllm-project/vllm-gaudi.git
+          cd /tmp/vllm-gaudi/.cd/server
+          
+          python << 'PYTHON_EOF'
+          import sys
+          sys.path.insert(0, '/tmp/vllm-gaudi/.cd/')
+          
+          from server.vllm_autocalc import VarsGenerator
+          
+          # Initialize with absolute file paths
+          vars_gen = VarsGenerator(
+              defaults_path="/tmp/vllm-gaudi/.cd/server/server_defaults.yaml",
+              varlist_conf_path="/tmp/vllm-gaudi/.cd/server/server_user.env",
+              model_def_settings_path="/tmp/vllm-gaudi/.cd/server/settings_vllm.csv"
+          )
+          
+          # Calculate and get variables
+          context = vars_gen.calculate_variables()
+
+          # Override or set specific values
+          context['MAX_NUM_BATCHED_TOKENS'] = max(context['MAX_NUM_BATCHED_TOKENS'], context['MAX_MODEL_LEN'])
+          
+          print("=== ALL GENERATED VARIABLES ===")
+          for key, value in sorted(context.items()):
+              print(f"{key}: {value} (type: {type(value).__name__})")
+          print("================================")
+          
+          # vLLM api_server recognized arguments (lowercase with hyphens)
+          vllm_args = {
+              'block-size', 'dtype', 'max-model-len', 'gpu-memory-utilization', 'max-num-seqs',
+              'max-num-prefill-seqs', 'num-scheduler-steps', 'use-padding-aware-scheduling',
+              'tensor-parallel-size', 'max-num-batched-tokens'
+          }
+
+          args_list = []
+          env_vars = {}
+          
+          for key, value in context.items():
+              # Convert to lowercase and replace underscores with hyphens
+              arg_key = key.lower().replace('_', '-')
+              
+              # Skip complex types and None values
+              if isinstance(value, (dict, list)) or value is None:
+                  continue
+              
+              # Check if it should be a vLLM argument
+              if arg_key in vllm_args:
+                  if isinstance(value, bool):
+                      if value:
+                          args_list.append(f'--{arg_key}')
+                  else:
+                      args_list.append(f'--{arg_key}={value}')
+              # Everything else: store as environment variable (uppercase original key)
+              else:
+                  if not isinstance(value, (dict, list)):
+                      env_vars[key] = str(value)
+
+          with open('/config/vllm_autocalc_output.txt', 'w') as f:
+              f.write(' '.join(args_list))
+          
+          with open('/config/env_vars.txt', 'w') as f:
+              for k, v in env_vars.items():
+                  f.write(f"export {k}={v}\n")
+
+          print(f"\n=== vLLM ARGS ===")
+          print(f"Generated vLLM args: {' '.join(args_list)}")
+          print(f"\n=== ENV VARS ===")
+          for k, v in env_vars.items():
+              print(f"{k}={v}")
+          PYTHON_EOF
+          
+          source /config/env_vars.txt
+          exec python -m vllm.entrypoints.openai.api_server \
+            --port=8080 \
+            --model=/mnt/models \
+            --served-model-name={{.Name}} \
+            --enable-auto-tool-choice \
+            --tool-call-parser=llama3_json \
+            --chat-template=/app/data/template/tool_chat_template_llama3.2_json.jinja \
+            $(cat /config/vllm_autocalc_output.txt)
       env:
         - name: HF_HOME
           value: "/tmp/hf_home"
+        - name: MODEL
+          value: "meta-llama/Llama-3.2-3B-Instruct"
       image: 'quay.io/modh/vllm:vllm-gaudi-v2-25-on-push-n7985-build-images'
       name: kserve-container
       ports:
@@ -47,6 +116,8 @@ spec:
       volumeMounts:
         - mountPath: /dev/shm
           name: shm
+        - mountPath: /config
+          name: generated-config
   multiModel: false
   supportedModelFormats:
     - autoSelect: true
@@ -56,3 +127,5 @@ spec:
         medium: Memory
         sizeLimit: 2Gi
       name: shm
+    - emptyDir: {}
+      name: generated-config


### PR DESCRIPTION
- Add specific vLLM parameters for optimal performance on models for HPU and CPU. 
- Switch to use the new vLLM CPU image built on top of the Red Hat Universal Base Image (UBI) to have AMX support. 
- Update CPU requirements to 4th Gen Xeon or newer.
- HPU: use auto-generated ENV and ARG variables for vLLM
- Make deployment namespace/project agnostic
- Add clean up instructions